### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libudev-dev
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Run tests
+        run: cargo test --all --locked


### PR DESCRIPTION
## Summary
- automate tests by running on `pull_request`
- install required OS packages and run `cargo test`

## Testing
- `cargo fmt -- --check`
- `cargo check`
- `cargo clippy`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6840a57e62c8832da0bee344cb38a1e4